### PR TITLE
Dockerfile housecleaning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN \
  echo "**** Installing runtime packages ****" && \
  apk add --no-cache \
 	curl \
-	sudo \
 	php7 \
-	curl \
 	php7-curl \
-	php7-sqlite3
+	php7-sqlite3 \
+	sudo
 RUN \
  echo "**** Installing BarcodeBuddy ****" && \
  mkdir -p /app/bbuddy && \


### PR DESCRIPTION
I originally forked because I was having issues with it, but those ended up being something else.

I did find that `curl` was installed twice. I recently saw that a best practice is to keep them in alphabetical order to help prevent that type of problem, so I did that as well.

Otherwise, untouched from yours.