### PR TITLE
Soft-fail chown during container init

### DIFF
--- a/supervisor/fileinit/fileinit.go
+++ b/supervisor/fileinit/fileinit.go
@@ -23,10 +23,12 @@ func initPaths() {
 }
 
 func setPermissions() {
-	err := osutils.ChownFolderRecursive("/app", "barcodebuddy")
-	check(err)
-	err = osutils.ChownFolderRecursive("/config", "barcodebuddy")
-	check(err)
+	if err := osutils.ChownFolderRecursive("/app", "barcodebuddy"); err != nil {
+		log.Printf("Warning: chown /app failed: %v (continuing)", err)
+	}
+	if err := osutils.ChownFolderRecursive("/config", "barcodebuddy"); err != nil {
+		log.Printf("Warning: chown /config failed: %v (continuing)", err)
+	}
 	fmt.Println("File permissions set")
 }
 


### PR DESCRIPTION
## Summary
The supervisor's `setPermissions()` calls `ChownFolderRecursive` on `/app` and `/config` and `log.Fatal`s on any error. On filesystems where root cannot chown arbitrary files — notably NFS exports with `root_squash` (common on K8s home labs and NAS-backed clusters) — this prevents the container from starting, even though `/config` is typically already writable.

This change logs a warning and continues. The chown is a best-effort permission tighten-up; nginx/php-fpm only need write access inside `/config/data`, which is satisfied by the volume's existing mode regardless of ownership.

## Test plan
- [x] Verified container starts on NFS-backed PVC (Synology export with root_squash) — supervisor logs the chown warning, then proceeds through SSL key generation, nginx/php-fpm/redis/wsserver startup
- [x] Verified the web UI is reachable and PHP can read/write `/config/data` (SQLite DB created)
- [x] Behaviour on local FS unchanged — chown still succeeds, no warning logged

Happy to narrow the soft-fail to `errors.Is(err, syscall.EPERM)` if you'd prefer to keep `log.Fatal` for genuine permission errors (e.g. read-only mount), or move it behind an env var. Let me know.